### PR TITLE
Add contact fields (phone + social media) to user

### DIFF
--- a/db/migrate/20170520133954_add_contact_fields_to_user.rb
+++ b/db/migrate/20170520133954_add_contact_fields_to_user.rb
@@ -1,0 +1,13 @@
+class AddContactFieldsToUser < ActiveRecord::Migration[5.1]
+  def change
+    change_table :users do |t|
+      t.string :phone
+      t.string :facebook_username
+      t.string :twitter_handle
+      t.string :instagram_username
+      t.string :tumblr_name
+      t.string :linkedin_username
+      t.string :pinterest_name
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170519204025) do
+ActiveRecord::Schema.define(version: 20170520133954) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "hstore"
-
-  create_table "positions", force: :cascade do |t|
-    t.string "name"
-    t.string "position_type"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
 
   create_table "posts", force: :cascade do |t|
     t.string "caption"
@@ -33,14 +26,6 @@ ActiveRecord::Schema.define(version: 20170519204025) do
     t.integer "photo_file_size"
     t.datetime "photo_updated_at"
     t.index ["user_id"], name: "index_posts_on_user_id"
-  end
-
-  create_table "programs", force: :cascade do |t|
-    t.string "name"
-    t.datetime "start_date"
-    t.datetime "end_date"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|
@@ -72,6 +57,13 @@ ActiveRecord::Schema.define(version: 20170519204025) do
     t.string "unconfirmed_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "phone"
+    t.string "facebook_username"
+    t.string "twitter_handle"
+    t.string "instagram_username"
+    t.string "tumblr_name"
+    t.string "linkedin_username"
+    t.string "pinterest_name"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
Adding phone and social media fields directly on user. These will each need privacy settings so they can individually be displayed/hidden per user preferences. 

Did not add these fields to the views, since those are currently empty and being worked on by the front end folks.