### PR TITLE
Add caching to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 script:
   - bundle exec rake db:create RAILS_ENV=test && bundle exec rake db:migrate RAILS_ENV=test
   - bundle exec rspec


### PR DESCRIPTION
Help all the RubyforGood builds go through the queue faster. On other projects, I've seen one minute shaved off from some test runs.