### PR TITLE
Issue #130 - Styling Announcements and adding logic so it doesnt appear when there are none, styling gallery page overall with flexbox

### DIFF
--- a/app/assets/stylesheets/gallery.scss
+++ b/app/assets/stylesheets/gallery.scss
@@ -1,16 +1,45 @@
 .gallery {
   display: flex;
-  padding-top: 1rem;
+  flex-direction: column;
+  padding: 1rem;
   color: #666;
   position: relative;
   @media #{$tablet} {
     flex-direction: column;
   }
 
+  &-announcements {
+    box-shadow: 0 1px 15px -5px rgba(0, 0, 0, 0.9);
+    padding: 1rem;
+    padding-bottom: 2rem;
+    background-color: white;
+    width: 100%;
+    height: 20rem;
+    margin-bottom: 1rem;
+    overflow-y: scroll;
+    opacity: 0.8;
+
+    &-item {
+      margin: 0.5rem 0;
+      background-color: $beige2;
+      border: 0;
+      color: #666;
+    }
+  }
+
+  &-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+  }
+
   &-socialFeed {
     margin-top: 2rem;
     width: 100%;
     margin: 0 auto;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
 
     h3 {
       margin-bottom: 2rem;
@@ -21,7 +50,6 @@
       padding: 1rem 1rem 2rem 1rem;
       background-color: white;
       width: 100%;
-      margin: 0 auto;
       margin-bottom: 1rem;
       font-size: 0.8rem;
     }
@@ -34,14 +62,12 @@
     width: 48%;
     height: 30rem;
     overflow-y: scroll;
-    float: left;
   }
 
   &-facebook {
     @media #{$tablet} {
       width: 100%;
     }
-    float: right;
     display: block;
     height: 30rem;
     overflow-y: scroll;
@@ -52,8 +78,7 @@
     @media #{$tablet} {
       width: 100%;
     }
-    padding: 1rem;
-    width: 70%;
+    width: 68%;
     opacity: 0.8;
   }
 
@@ -61,17 +86,15 @@
     @media #{$tablet} {
       width: 100%;
     }
-    padding: 1rem;
-    padding-right: 2rem;
     width: 30%;
     opacity: 0.8;
+    display: flex;
+    flex-direction: column;
 
     &-boxes {
       box-shadow: 0 2px 15px -5px rgba(0, 0, 0, 0.9);
       padding: 1rem 1rem 2rem 1rem;
       background-color: white;
-      width: 90%;
-      margin: 0 auto;
       margin-bottom: 1rem;
       font-size: 0.8rem;
 

--- a/app/assets/stylesheets/shared/variables.scss
+++ b/app/assets/stylesheets/shared/variables.scss
@@ -9,6 +9,7 @@ $green-background: #3E6549;
 $orange: #CE7F4A;
 $yello2: #D3BB72;
 $beige: #E7E8B8;
+$beige2: #f2f2de;
 
 $mobile: "(max-width: 544px)";
 $tablet: "(max-width: 768px)";

--- a/app/views/home/_announcements.html.erb
+++ b/app/views/home/_announcements.html.erb
@@ -1,0 +1,8 @@
+<div class="gallery-announcements">
+  <h3>Announcements</h3>
+  <ul class="gallery-announcements-list list-group">
+  <% @announcements.each do |announcement| %>
+    <li class="gallery-announcements-item list-group-item"><%= announcement.text %></li>
+  <% end %>
+  </ul>
+</div>

--- a/app/views/home/_gallery.html.erb
+++ b/app/views/home/_gallery.html.erb
@@ -1,71 +1,67 @@
-<div class="gallery-announcements text-center">
-  <h5>Announcements</h5>
-  <ul class="list-group">
-  <% @announcements.each do |announcement| %>
-    <li class="list-group-item"><%= announcement.text %></li>
-  <% end %>
-  </ul>
-</div>
 <div class="gallery">
   <div class="gallery-linedetail">
   </div>
-  <div class="gallery-left">
-    <div class="gallery-photos">
 
-      <h3><%= link_to 'The Greenhouse', posts_path%><%= link_to '+ Upload Photo', new_post_path, class: "gallery-photos-add" %></h3>
+  <%= render 'announcements' if @announcements.present? %>
 
-    <div class="row">
-      <%= form_tag(posts_path, :method => "get", id: "search-tags-form") do %>
-        <%= text_field_tag :tag, params[:tag], placeholder: "Search by tag", style: "margin-left:15px;" %>
-        <%= submit_tag "Search", class: "btn btn-primary" %>
-        <%= link_to 'Clear', posts_path, class: "btn btn-outline-success"%>
-      <% end %>
-    </div>
+  <div class="gallery-container">
+    <div class="gallery-left">
+      <div class="gallery-photos">
+        <h3><%= link_to 'The Greenhouse', posts_path%><%= link_to '+ Upload Photo', new_post_path, class: "gallery-photos-add" %></h3>
 
-      <div class="gallery-photos-tags">
-        Filter by popular tags: <% @tags.each do |t| %>
-          <%= link_to t.name, (root_path + "?tag=#{t.name}") %>
+      <div class="row">
+        <%= form_tag(posts_path, :method => "get", id: "search-tags-form") do %>
+          <%= text_field_tag :tag, params[:tag], placeholder: "Search by tag", style: "margin-left:15px;" %>
+          <%= submit_tag "Search", class: "btn btn-primary" %>
+          <%= link_to 'Clear', posts_path, class: "btn btn-outline-success"%>
         <% end %>
       </div>
-      <%= render 'photos' %>
-    </div>
-    <div class="gallery-socialFeed">
-      <%= render 'social_feed' %>
-    </div>
-  </div>
 
-  <div class="gallery-right">
-    <div class="gallery-events gallery-right-boxes">
-      <h5><%= link_to "Calendar",
-                      "https://www.doublehranch.org/calendar",
-                      target: "_blank" %></h5>
-      Check out our awesome upcoming events for Double H Ranch! <br />
-      <%= link_to '<button type="button" class="btn btn-primary btn-block">Browse</button>'.html_safe,
-                  'https://www.doublehranch.org/calendar',
-                  target: "_blank" %>
+        <div class="gallery-photos-tags">
+          Filter by popular tags: <% @tags.each do |t| %>
+            <%= link_to t.name, (root_path + "?tag=#{t.name}") %>
+          <% end %>
+        </div>
+        <%= render 'photos' %>
+      </div>
+      <div class="gallery-socialFeed">
+        <%= render 'social_feed' %>
+      </div>
     </div>
-    <div class="gallery-volunteer gallery-right-boxes">
-      <h5><%= link_to "Volunteer",
-                      "https://www.doublehranch.org/volunteer",
-                      target: "_blank" %></h5>
-      Every set of hands make the work lighter and the applause louder.
-      Whether you have a day, weekend, week or an entire summer,
-      our camp offers a range of volunteer opportunities for you to make a difference
-      by giving your time and talent.<br />
-      <%= link_to '<button type="button" class="btn btn-primary btn-block">Apply</button>'.html_safe,
-                  'https://www.doublehranch.org/volunteer',
-                  target: "_blank" %>
-    </div>
-    <div class="gallery-donate gallery-right-boxes">
-      <h5><%= link_to "Donate",
-                      "https://www.doublehranch.org/donate", target: "_blank" %></h5>
-      Your support is what enables us to continue providing our year-round programs to our campers.
-      Together, there’s no telling how many lives we can touch and how many stories we can
-      inspire as we continue to keep the promise to our campers that the
-      Double H Ranch will be here forever. <br />
-      <%= link_to '<button type="button" class="btn btn-primary btn-block">Donate</button>'.html_safe,
-                  'https://www.doublehranch.org/donate',
-                  target: "_blank" %>
+
+    <div class="gallery-right">
+      <div class="gallery-right-boxes">
+        <h5><%= link_to "Calendar",
+                        "https://www.doublehranch.org/calendar",
+                        target: "_blank" %></h5>
+        Check out our awesome upcoming events for Double H Ranch! <br />
+        <%= link_to '<button type="button" class="btn btn-primary btn-block">Browse</button>'.html_safe,
+                    'https://www.doublehranch.org/calendar',
+                    target: "_blank" %>
+      </div>
+      <div class="gallery-right-boxes">
+        <h5><%= link_to "Volunteer",
+                        "https://www.doublehranch.org/volunteer",
+                        target: "_blank" %></h5>
+        Every set of hands make the work lighter and the applause louder.
+        Whether you have a day, weekend, week or an entire summer,
+        our camp offers a range of volunteer opportunities for you to make a difference
+        by giving your time and talent.<br />
+        <%= link_to '<button type="button" class="btn btn-primary btn-block">Apply</button>'.html_safe,
+                    'https://www.doublehranch.org/volunteer',
+                    target: "_blank" %>
+      </div>
+      <div class="gallery-right-boxes">
+        <h5><%= link_to "Donate",
+                        "https://www.doublehranch.org/donate", target: "_blank" %></h5>
+        Your support is what enables us to continue providing our year-round programs to our campers.
+        Together, there’s no telling how many lives we can touch and how many stories we can
+        inspire as we continue to keep the promise to our campers that the
+        Double H Ranch will be here forever. <br />
+        <%= link_to '<button type="button" class="btn btn-primary btn-block">Donate</button>'.html_safe,
+                    'https://www.doublehranch.org/donate',
+                    target: "_blank" %>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
For Issue #130 Adding some styling to the Announcements so that the box is similar to the others on the page. It spans across so it stands out a bit from the other boxes. It's scrollable and the box doesn't appear if there are no announcements. I also updated some CSS in the gallery page in general to use flexbox. Yay flexbox!

<img width="1419" alt="screen shot 2017-08-19 at 11 03 58 am" src="https://user-images.githubusercontent.com/8590508/29487890-6d396ad0-84ce-11e7-9d22-aeec4870a9aa.png">
