### PR TITLE
gets Model testing started with rspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ end
 group :test do
   gem 'rake'
   gem 'database_cleaner'
+  gem 'shoulda-matchers', '4.0.0.rc1'
+  gem 'rails-controller-testing' # If you are using Rails 5.x
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,10 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 5.1.1)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.4)
+      actionpack (>= 5.0.1.x)
+      actionview (>= 5.0.1.x)
+      activesupport (>= 5.0.1.x)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -288,6 +292,8 @@ GEM
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
+    shoulda-matchers (4.0.0.rc1)
+      activesupport (>= 4.2.0)
     simple_form (3.5.0)
       actionpack (> 4, < 5.2)
       activemodel (> 4, < 5.2)
@@ -363,6 +369,7 @@ DEPENDENCIES
   puma (~> 3.7)
   pundit
   rails (~> 5.1.0)
+  rails-controller-testing
   rails4-autocomplete
   rails_admin (~> 1.1.1)
   rails_admin_pundit!
@@ -371,6 +378,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   selenium-webdriver
+  shoulda-matchers (= 4.0.0.rc1)
   simple_form (~> 3.5)
   spring
   spring-watcher-listen (~> 2.0.0)
@@ -383,4 +391,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.1
+   1.17.1

--- a/spec/factories/announcement.rb
+++ b/spec/factories/announcement.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :annoucement do
+    text { "Something big is happening soon...." }
+    start_date { Date.today }
+    end_date { Date.today + 2 }
+  end
+end

--- a/spec/factories/comment.rb
+++ b/spec/factories/comment.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :comment do
+    title { "nice comment" }
+    comment { "just wanted to say how lovely it is today" }
+    commentable_type { "Post" }
+    commentable
+    user
+    role { "comments" }
+  end
+end

--- a/spec/factories/email_template.rb
+++ b/spec/factories/email_template.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :email_template do
+    label { "2019 goals" }
+    subject { "news from the chief" }
+    body { "You know the drill. We make goals and achieve them!" }
+    author
+  end
+end

--- a/spec/factories/positions.rb
+++ b/spec/factories/positions.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :position do
-    
+    name { "Baker" }
+    position_type { "Facility Staff" }
   end
 end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Announcement, type: :model do
+  let(:surprise) { FactoryGirl.create(:announcement) }
+
+  describe "announcement validations" do
+    it { is_expected.to validate_presence_of(:text) }
+    it { is_expected.to validate_presence_of(:start_date) }
+    it { is_expected.to validate_presence_of(:end_date) }
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  let(:nice_one) { FactoryGirl.create(:comment) }
+
+  describe "comment validations" do
+    it { is_expected.to allow_value(nil).for(:title) }
+    it { is_expected.to allow_value(nil).for(:comment) }
+    it { is_expected.to allow_value("Post").for(:commentable_type) }
+    it { is_expected.to allow_value("comments").for(:role) }
+  end
+
+  describe "comment associations" do
+    it { is_expected.to belong_to(:commentable) }
+    it { is_expected.to belong_to(:user) }
+  end
+end

--- a/spec/models/email_template_spec.rb
+++ b/spec/models/email_template_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe EmailTemplate, type: :model do
+  let(:just_cluttering_my_inbox) { FactoryGirl.create(:email_template) }
+
+  describe "email_template validations" do
+    it { is_expected.to validate_presence_of(:label) }
+    it { is_expected.to validate_uniqueness_of(:label) }
+    it { is_expected.to validate_presence_of(:subject) }
+    it { is_expected.to validate_presence_of(:body) }
+  end
+
+  describe "email template associations" do
+    it { is_expected.to belong_to(:author) }
+  end
+end

--- a/spec/models/position_spec.rb
+++ b/spec/models/position_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe Position, type: :model do
+  let(:nice_one) { FactoryGirl.create(:position) }
+
+  describe "position validations" do
+    it { is_expected.to allow_value(nil).for(:name) }
+    it { is_expected.to allow_value(nil).for(:position_type) }
+  end
+
+  describe "position associations" do
+    it { is_expected.to have_many(:positions_held) }
+    it { is_expected.to have_many(:users) }
+  end
+end

--- a/spec/models/positions_held_spec.rb
+++ b/spec/models/positions_held_spec.rb
@@ -1,5 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe PositionsHeld, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:leadership_role) { FactoryGirl.create(:positions_held) }
+
+  describe "positions held validations" do
+    it { is_expected.to allow_value(nil).for(:position) }
+    it { is_expected.to allow_value(nil).for(:program) }
+  end
+
+  describe "positions held associations" do
+    it { is_expected.to belong_to(:user) }
+  end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,4 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe Post, type: :model do
+  let(:another_post) { FactoryGirl.create(
+    caption: "Super",
+    user: user,
+    photo_file_name: "pretty",
+    photo_content_type: "jpg",
+    photo_file_size: 4,
+    photo_updated_at: Date.Today,
+    hide: false
+  )}
+
+  describe "email_template validations" do
+    it { is_expected.to allow_value(nil).for(:caption) }
+    it { is_expected.to allow_value(nil).for(:photo_file_name) }
+    it { is_expected.to allow_value(nil).for(:photo_content_type) }
+    it { is_expected.to allow_value(nil).for(:photo_file_size) }
+    it { is_expected.to allow_value(nil).for(:photo_updated_at) }
+    it { is_expected.to allow_value(true, false).for(:hide) }
+  end
+
+  describe "email template associations" do
+    it { is_expected.to belong_to(:user) }
+  end
 end

--- a/spec/models/program_spec.rb
+++ b/spec/models/program_spec.rb
@@ -1,5 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Program, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:exercise) { FactoryGirl.create(:program) }
+
+  describe "program validations" do
+    it { is_expected.to allow_value(nil).for(:name) }
+    it { is_expected.to allow_value(nil).for(:start_date) }
+    it { is_expected.to allow_value(nil).for(:end_date) }
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  let(:princess_peach) { FactoryGirl.create(:user) }
+
+  describe "comment validations" do
+    it { is_expected.to validate_presence_of(:first_name) }
+    it { is_expected.to validate_presence_of(:last_name) }
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to allow_value(nil).for(:phone) }
+    it { is_expected.to allow_value(nil).for(:street_address) }
+    it { is_expected.to allow_value(nil).for(:city) }
+    it { is_expected.to allow_value(nil).for(:state) }
+    it { is_expected.to allow_value(nil).for(:country) }
+    it { is_expected.to allow_value(nil).for(:zip_code) }
+    it { is_expected.to allow_value(nil).for(:nickname) }
+    it { is_expected.to allow_value(nil).for(:facebook_username) }
+    it { is_expected.to allow_value(nil).for(:twitter_handle) }
+    it { is_expected.to allow_value(nil).for(:instagram_username) }
+    it { is_expected.to allow_value(nil).for(:tumblr_name) }
+    it { is_expected.to allow_value(nil).for(:linkedin_username) }
+    it { is_expected.to allow_value(nil).for(:pinterest_name) }
+    it { is_expected.to allow_value(nil).for(:profile_photo_file_name) }
+    it { is_expected.to allow_value(nil).for(:profile_photo_content_type) }
+    it { is_expected.to allow_value(nil).for(:profile_photo_file_size) }
+    it { is_expected.to allow_value(true, false).for(:subscribed_to_alumni_newsletter) }
+    it { is_expected.to allow_value(true, false).for(:admin) }
+    it { is_expected.to validate_inclusion_of(:salutation).in_array(['Mr.', 'Ms.', 'Mrs.', 'Dr.']) }
+  end
+
+  describe "comment associations" do
+    it { is_expected.to have_many(:email_templates) }
+    it { is_expected.to have_many(:positions_held) }
+    it { is_expected.to have_many(:positions) }
+    it { is_expected.to have_many(:programs) }
+    it { is_expected.to have_many(:posts) }
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -70,3 +70,11 @@ RSpec.configure do |config|
     Warden.test_reset!
   end
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+
+    with.library :rails
+  end
+end


### PR DESCRIPTION
Adds model testing with rspec. Issue #132 

- adds passing tests to models. Note: There are rather few attribute validations in the model files....might be a good addition to ensure more strict data going into the db
- adds [shoulda matchers](https://github.com/thoughtbot/shoulda-matchers) for use in specs 
- makes use of FactoryGirl for stubbing

/cc @maebeale @kalimar 